### PR TITLE
Add some additional options to make_normalised_raster()

### DIFF
--- a/R/make_normalised_raster.R
+++ b/R/make_normalised_raster.R
@@ -3,22 +3,58 @@ make_normalised_raster <- function(raster_in,
                                    iso3,
                                    invert = FALSE,
                                    rescaled = TRUE,
+                                   method_override = NULL,
+                                   conditional_expression = NULL,
+                                   fill_na = TRUE,
                                    name_out,
                                    output_path = NULL) {
-  # Reproject the planning units (PUs) to match the projection of the input raster
-  pus_reproject <- terra::project(pus, terra::crs(raster_in))
+  # Valid methods for terra::project
+  valid_terra_methods <- c("near", "bilinear", "cubic", "cubicspline", "lanczos", "min", "q1", "med", "q3", "max", "average", "mode", "rms")
 
-  # Crop the input raster to the extent of the planning units
-  dat_aligned <- terra::crop(raster_in, pus_reproject)
+  # Temporarily reproject pus to the CRS of raster_in for resolution comparison
+  pus_temp <- terra::project(pus, terra::crs(raster_in))
 
-  # Replace NA values in the cropped raster with 0
+  # Calculate resolutions of both rasters in the same CRS
+  raster_res <- min(terra::res(raster_in))    # Minimum resolution of input raster
+  pus_res <- min(terra::res(pus_temp))        # Minimum resolution of re-projected pus
+
+  # Determine the appropriate projection method based on data type and resolution comparison
+  if (!is.null(method_override)) {
+    if (!(method_override %in% valid_terra_methods)) {
+      stop("Invalid method_override. Choose one of: ", paste(valid_terra_methods, collapse = ", "))
+    }
+    method <- method_override  # Use the override method if provided and valid
+  } else {
+    # Default method selection based on data type and resolution comparison
+    method <- if (terra::is.int(raster_in)) {
+      if (raster_res >= pus_res) "near" else "mode"
+    } else {
+      if (raster_res >= pus_res) "near" else "bilinear"
+    }
+  }
+
+  # Apply the conditional expression if provided
+  if (!is.null(conditional_expression)) {
+    raster_in <- conditional_expression(raster_in)
+  }
+
+  # Re-project the original raster_in to match PUs with the selected method
+  dat_aligned <- terra::project(
+    x = raster_in,
+    y = pus,
+    method = method,
+    threads = TRUE
+  )
+
+  # Fill in NA background values before masking
+  if (fill_na) {
+
   dat_aligned[is.na(dat_aligned)] <- 0
 
-  # Align projection and extent of the raster with the planning units
-  dat_aligned <- dat_aligned %>%
-    terra::project(terra::crs(pus)) %>%  # Project to original PU CRS
-    terra::resample(pus) %>%             # Resample to match resolution and extent of PUs
-    terra::mask(pus, maskvalues = 0)     # Mask areas outside of planning units (assuming outside = 0)
+  dat_aligned <- dat_aligned |>
+    terra::mask(pus) # Mask areas outside of planning units
+
+  }
 
   # Invert values if required
   if (invert) {
@@ -35,13 +71,8 @@ make_normalised_raster <- function(raster_in,
   # Save the output file if output_path is provided
   if (!is.null(output_path)) {
     # Determine the appropriate data type and NoData value for saving the raster
-    if (terra::is.int(dat_aligned)) {
-      data_type <- "INT2S"  # 16-bit signed integer
-      na_value <- 255       # Byte-specific NoData value
-    } else {
-      data_type <- "FLT4S"  # 32-bit float
-      na_value <- -9999     # Float-specific NoData value
-    }
+    data_type <- if (terra::is.int(dat_aligned)) "INT1S" else "FLT4S"  # Adjust data type
+    na_value <- if (terra::is.int(dat_aligned)) 255 else -9999         # Adjust NoData value
 
     # Write the raster with the determined settings
     terra::writeRaster(

--- a/R/make_normalised_raster.R
+++ b/R/make_normalised_raster.R
@@ -1,36 +1,3 @@
-#' Function to extract general raster data
-#'
-#' `make_normalised_raster()`allows you to align, normalise and save a raster file. This is applicable for the following data
-#' This is applicable for the following data sets: certified forests, drought risk, flood risk, intact wilderness area, soc difference, threatened species richness, voc, wad convergence evidence
-#'
-#' @param raster_in A `SpatRaster` file that contains the data to be put into right format
-#' @param pus A `SpatRaster` file that contains the reference spatial extent, crs etc.in form of the planning units
-#' @param iso3 A string of the iso3 name of the data (country name)
-#' @param invert Logical. Default is FALSE. If TRUE, highest values in the original dataset should be valued the lowest in the prioritisation.
-#' @param rescaled Logical. Default is TRUE. Should remain TRUE unless there is a very specific reason not to rescale.
-#' @param name_out A string with the data name that will be used for the output `tif`file
-#' @param output_path An optional output path for the created file.
-#'
-#' @return A `SpatRaster` file that has been aligned and normalised
-#' @export
-#'
-#' @examples
-#' boundary_proj <- make_boundary(
-#'   boundary_in = boundary_dat,
-#'   iso3 = "NPL",
-#'   iso3_column = "iso3cd",
-#'   do_project = TRUE
-#' )
-#'
-#' pus <- make_planning_units(boundary_proj = boundary_proj,
-#'                            pu_size = NULL,
-#'                            pu_threshold = 8.5e5,
-#'                            limit_to_mainland = FALSE)
-#' wad_dat <- get_wad_data()
-#'
-#' wadOut <- make_normalised_raster(raster_in = wad_dat,
-#'                                  pus = pus,
-#'                                  iso3 = "NPL")
 make_normalised_raster <- function(raster_in,
                                    pus,
                                    iso3,
@@ -38,37 +5,53 @@ make_normalised_raster <- function(raster_in,
                                    rescaled = TRUE,
                                    name_out,
                                    output_path = NULL) {
-  # reprojecting the global data would take too long
-  # to speed up: reproject PUs to projection of global data first
+  # Reproject the planning units (PUs) to match the projection of the input raster
   pus_reproject <- terra::project(pus, terra::crs(raster_in))
 
-  # then crop (make data a lot smaller)
+  # Crop the input raster to the extent of the planning units
   dat_aligned <- terra::crop(raster_in, pus_reproject)
 
+  # Replace NA values in the cropped raster with 0
   dat_aligned[is.na(dat_aligned)] <- 0
 
+  # Align projection and extent of the raster with the planning units
   dat_aligned <- dat_aligned %>%
-    terra::project(., terra::crs(pus)) %>% # reproject the data to the crs we actually want (the original pu crs)
-    terra::resample(., pus) %>%
-    terra::mask(pus, maskvalues = 0) # maskvalues denotes the background value in the raster that's not data (since this should always be planning region/units is 1 and outside is 0, this is hard-coded to 0)
+    terra::project(terra::crs(pus)) %>%  # Project to original PU CRS
+    terra::resample(pus) %>%             # Resample to match resolution and extent of PUs
+    terra::mask(pus, maskvalues = 0)     # Mask areas outside of planning units (assuming outside = 0)
 
+  # Invert values if required
   if (invert) {
-    dat_aligned = -dat_aligned
+    dat_aligned <- -dat_aligned
   }
 
+  # Rescale the raster if needed
   if (rescaled) {
     dat_aligned <- rescale_raster(dat_aligned)
   } else {
     warning("NOTE: Raster is NOT rescaled.")
   }
 
+  # Save the output file if output_path is provided
   if (!is.null(output_path)) {
-    terra::writeRaster(dat_aligned,
-                       glue::glue("{output_path}/{name_out}_{iso3}.tif"),
-                       gdal = c("COMPRESS=DEFLATE"),
-                       NAflag = -9999,
-                       overwrite = TRUE,
-                       filetype = "COG"
+    # Determine the appropriate data type and NoData value for saving the raster
+    if (terra::is.int(dat_aligned)) {
+      data_type <- "INT2S"  # 16-bit signed integer
+      na_value <- 255       # Byte-specific NoData value
+    } else {
+      data_type <- "FLT4S"  # 32-bit float
+      na_value <- -9999     # Float-specific NoData value
+    }
+
+    # Write the raster with the determined settings
+    terra::writeRaster(
+      dat_aligned,
+      glue::glue("{output_path}/{name_out}_{iso3}.tif"),
+      gdal = c("COMPRESS=ZSTD", "NUM_THREADS=4", "OVERVIEWS=NONE", "PREDICTOR=3"),
+      datatype = data_type,
+      NAflag = na_value,
+      overwrite = TRUE,
+      filetype = "COG"
     )
   }
 

--- a/R/make_normalised_raster.R
+++ b/R/make_normalised_raster.R
@@ -4,16 +4,16 @@
 #' optionally inverts, rescales, applies conditional expressions, and saves the processed
 #' raster to a specified output path.
 #'
-#' @param raster_in [SpatRaster] The input raster to be processed.
-#' @param pus [SpatVector] The planning units (PUs) to align the raster to.
-#' @param iso3 [character] ISO3 country code used for naming the output file.
-#' @param invert [logical] If `TRUE`, inverts the raster values (default: `FALSE`).
-#' @param rescaled [logical] If `TRUE`, rescales the raster using `rescale_raster()` (default: `TRUE`).
-#' @param method_override [character] Optional method for `terra::project()`, overriding the default (default: `NULL`).
-#' @param conditional_expression [function] Optional method to apply a function to the raster before resampling to the PU layer (default: `NULL`).
-#' @param fill_na [logical] If `TRUE`, fills `NA` values with 0 before masking (default: `TRUE`).
-#' @param name_out [character] The name of the output raster file (without the extension).
-#' @param output_path [character] The directory path to save the output raster (default: `NULL`, i.e., not saved).
+#' @param raster_in `SpatRaster` The input raster to be processed.
+#' @param pus `SpatVector` The planning units (PUs) to align the raster to.
+#' @param iso3 `character` ISO3 country code used for naming the output file.
+#' @param invert `logical` If `TRUE`, inverts the raster values (default: `FALSE`).
+#' @param rescaled `logical` If `TRUE`, rescales the raster using `rescale_raster()` (default: `TRUE`).
+#' @param method_override `character` Optional method for `terra::project()`, overriding the default (default: `NULL`).
+#' @param conditional_expression `function` Optional method to apply a function to the raster before resampling to the PU layer (default: `NULL`).
+#' @param fill_na `logical` If `TRUE`, fills `NA` values with 0 before masking (default: `TRUE`).
+#' @param name_out `character` The name of the output raster file (without the extension).
+#' @param output_path `character` The directory path to save the output raster (default: `NULL`, i.e., not saved).
 #'
 #' @details This function reprojects the input raster (`raster_in`) to match the CRS and resolution
 #' of the planning units (`pus`). The method for reprojection can be overridden using `method_override`.
@@ -93,7 +93,7 @@ make_normalised_raster <- function(raster_in,
   # Fill in NA background values before masking
   if (fill_na) {
     dat_aligned[is.na(dat_aligned)] <- 0
-    dat_aligned <- dat_aligned |> terra::mask(pus) # Mask areas outside of planning units
+    dat_aligned <- dat_aligned %>% terra::mask(pus) # Mask areas outside of planning units
   }
 
   # Invert values if required

--- a/R/utils.R
+++ b/R/utils.R
@@ -135,5 +135,20 @@ extract_filename_filetype <- function(data_name, file_path) {
   return(list(filetype = filetype, filename = filename))
 }
 
-
-
+#' Calculate country areal coverage (as a percentage) of an input binary layer, likely representing a zone.
+#'
+#' @param zone_layer A binary spatRast representing a zone or protected area type feature.
+#' @param pu_layer A binary spatRast representing the planning units.
+#' @return A vector of areal targets of length 1.
+#'
+#' @seealso [terra::global()] which this function wraps.
+#' @export
+#' @examples
+#' \dontrun{
+#'    get_coverage(PA, pu)
+#'    get_coverage(zone_protect, pu)
+#'    get_coverage(zone_manage, pu)
+#' }
+get_coverage <- function(zone_layer, pu_layer) {
+  terra::global(zone_layer, sum, na.rm = TRUE)$sum / terra::global(pu_layer, sum, na.rm = TRUE)$sum * 100
+}


### PR DESCRIPTION
- add default resampling method defaults based on comparing resolutions of both PU and input raster.
- add manual override using terra default methods
- add conditional_expression to allow user to do simple single raster algebrda using defined function, (e.g., function (r) ifel(r > 4, 1, 0) )
- add fill_na option (default = TRUE) to fill in NA values to 0 before masking to PU layer
- add default output datatype (INT1S or FLT4S) and NAflag when writing to file based on raster number type.