### PR TITLE
57 In python, the int type uses a C long, which is always 32-bit on Windows.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Depends:
     R (>= 3.5.0)
 Imports: 
     assertthat,
+    bit64,
     dplyr,
     exactextractr,
     ggnewscale,

--- a/R/elsar_download_esri_lulc_data.R
+++ b/R/elsar_download_esri_lulc_data.R
@@ -164,7 +164,7 @@ elsar_download_esri_lulc_data <- function(
         fileNamePrefix = file_name,
         scale = 10,
         region = ee_bounding_box$getInfo()[["coordinates"]],
-        maxPixels = reticulate::r_to_py(bit64::as.integer64("10000000000000")), #1e13, #changed to int64 here
+        maxPixels = reticulate::r_to_py(1e13), #1e13, #changed to int64 here
         fileFormat = "GeoTIFF"
       )
       task$start()

--- a/R/elsar_download_esri_lulc_data.R
+++ b/R/elsar_download_esri_lulc_data.R
@@ -164,7 +164,7 @@ elsar_download_esri_lulc_data <- function(
         fileNamePrefix = file_name,
         scale = 10,
         region = ee_bounding_box$getInfo()[["coordinates"]],
-        maxPixels = 1e13,
+        maxPixels = reticulate::r_to_py(bit64::as.integer64("10000000000000")), #1e13, #changed to int64 here
         fileFormat = "GeoTIFF"
       )
       task$start()


### PR DESCRIPTION
https://github.com/ELSA-UNDP/elsar/issues/57
