### PR TITLE
Fixes attribute retrieval in exact rasterisation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Depends:
     R (>= 3.5.0)
 Imports: 
     assertthat,
+    bit64,
     dplyr,
     exactextractr,
     ggnewscale,

--- a/R/elsar_download_esri_lulc_data.R
+++ b/R/elsar_download_esri_lulc_data.R
@@ -164,7 +164,7 @@ elsar_download_esri_lulc_data <- function(
         fileNamePrefix = file_name,
         scale = 10,
         region = ee_bounding_box$getInfo()[["coordinates"]],
-        maxPixels = reticulate::r_to_py(bit64::as.integer64("10000000000000")), #1e13, #changed to int64 here
+        maxPixels = reticulate::r_to_py(1e13), #1e13, #changed to int64 here
         fileFormat = "GeoTIFF"
       )
       task$start()

--- a/R/elsar_download_esri_lulc_data.R
+++ b/R/elsar_download_esri_lulc_data.R
@@ -164,7 +164,7 @@ elsar_download_esri_lulc_data <- function(
         fileNamePrefix = file_name,
         scale = 10,
         region = ee_bounding_box$getInfo()[["coordinates"]],
-        maxPixels = 1e13,
+        maxPixels = reticulate::r_to_py(bit64::as.integer64("10000000000000")), #1e13, #changed to int64 here
         fileFormat = "GeoTIFF"
       )
       task$start()

--- a/R/make_urban_greening_opportunities.R
+++ b/R/make_urban_greening_opportunities.R
@@ -107,7 +107,7 @@ make_urban_greening_opportunities <- function(
       log_msg("No urban extreme heat `avg_intense` values to rasterise: returning empty raster.")
       urban_extreme_heat <- terra::ifel(pus == 1, 0, NA)
     } else {
-      urban_extreme_heat <- elsar::exact_rasterise(
+      urban_extreme_heat <- exact_rasterise(
         attribute = "avg_intens",
         features = urban_extreme_heat,
         pus = pus,

--- a/R/utils.R
+++ b/R/utils.R
@@ -251,7 +251,7 @@ exact_rasterise <- function(
     # Single feature: get coverage fraction directly.
     log_msg(glue::glue("Calculating weighted coverage fraction using a single feature..."))
     r_stack <- exactextractr::coverage_fraction(pus, features)[[1]]
-    r_stack <- r_stack * attr_val
+    r_stack <- r_stack * dplyr::pull(features, attribute)
   }
 
   # Normalise the final result


### PR DESCRIPTION
Updates the `exact_rasterise` function to correctly retrieve the attribute value for single-feature rasterisation. This ensures that the weighted coverage fraction is calculated using the correct value from the feature's attribute column, resolving an issue where the attribute value was not being properly accessed.
