### PR TITLE
Adds wait time parameter for GEE exports

### DIFF
--- a/R/elsar_download_esri_lulc_data.R
+++ b/R/elsar_download_esri_lulc_data.R
@@ -164,7 +164,7 @@ elsar_download_esri_lulc_data <- function(
         fileNamePrefix = file_name,
         scale = 10,
         region = ee_bounding_box$getInfo()[["coordinates"]],
-        maxPixels = 1e13,
+        maxPixels = reticulate::r_to_py(1e13), #1e13, #changed to int64 here
         fileFormat = "GeoTIFF"
       )
       task$start()


### PR DESCRIPTION
Allows users to specify the amount of time the function waits
for GEE exports to finish before stopping, providing more
control over timeout behaviour. The default wait time is set to
5 minutes.
