### PR TITLE
Adds background fill option

### DIFF
--- a/R/make_planning_units.R
+++ b/R/make_planning_units.R
@@ -16,6 +16,8 @@
 #'   when estimating PU size automatically.
 #' @param limit_to_mainland Logical. Reserved for future use. If `TRUE`, limits planning units to mainland regions only.
 #' @param iso3 Character. ISO3 country code used to name the output raster (e.g., "KEN", "BRA").
+#' @param background_fill The value to apply to all pixels outside the boundary_proj. This default to NA (e.g., nodata).
+#'   You should have a good reason for wanting to use a different value.
 #' @param output_path Optional character. Directory path to save the resulting raster. If `NULL`, the raster is not saved.
 #'
 #' @return A single-layer `SpatRaster` object from the `terra` package. All non-zero cells represent valid planning units.
@@ -35,6 +37,7 @@ make_planning_units <- function(boundary_proj,
                                 pu_tolerance = 0.05,
                                 limit_to_mainland = FALSE,
                                 iso3,
+                                background_fill = NA,
                                 output_path = NULL) {
 
   threshold_soft <- pu_threshold * (1 + pu_tolerance)
@@ -102,7 +105,7 @@ make_planning_units <- function(boundary_proj,
         rasterMask,
         touches = TRUE,
         update = TRUE,
-        background = 0
+        background = background_fill
       )
 
       pu_sum_temp <- terra::global(r_temp, sum, na.rm = TRUE)[[1]]
@@ -141,7 +144,7 @@ make_planning_units <- function(boundary_proj,
       rasterMask,
       touches = TRUE,
       update = TRUE,
-      background = 0
+      background = background_fill
     )
 
     pu_sum <- terra::global(r1, sum, na.rm = TRUE)[[1]]

--- a/man/make_planning_units.Rd
+++ b/man/make_planning_units.Rd
@@ -11,6 +11,7 @@ make_planning_units(
   pu_tolerance = 0.05,
   limit_to_mainland = FALSE,
   iso3,
+  background_fill = NA,
   output_path = NULL
 )
 }
@@ -30,6 +31,9 @@ when estimating PU size automatically.}
 \item{limit_to_mainland}{Logical. Reserved for future use. If \code{TRUE}, limits planning units to mainland regions only.}
 
 \item{iso3}{Character. ISO3 country code used to name the output raster (e.g., "KEN", "BRA").}
+
+\item{background_fill}{The value to apply to all pixels outside the boundary_proj. This default to NA (e.g., nodata).
+You should have a good reason for wanting to use a different value.}
 
 \item{output_path}{Optional character. Directory path to save the resulting raster. If \code{NULL}, the raster is not saved.}
 }


### PR DESCRIPTION
Adds an option to specify the background fill value for planning unit rasters.

- Allows users to define a fill value (e.g., `NA`) for areas outside the defined boundary.
- Defaults to `NA` to represent nodata values.