### PR TITLE
Fixes NA masking after fill_na

### DIFF
--- a/R/make_normalised_raster.R
+++ b/R/make_normalised_raster.R
@@ -150,7 +150,7 @@ make_normalised_raster <- function(raster_in,
 
   if (!is.null(fill_na)) {
     dat_aligned[is.na(dat_aligned)] <- fill_na
-    dat_aligned <- terra::mask(dat_aligned, pus, maskvalues = 0)
+    dat_aligned <- terra::mask(dat_aligned, pus, maskvalues = NA)
   }
 
   if (invert) {


### PR DESCRIPTION
Ensures that NA values are correctly used
when masking the raster after filling NA values
with a specified value.

This prevents incorrect masking where 0 was
unintentionally being used as a mask value.
