### PR TITLE
Revert to coercing max_pixels to numeric in export task

### DIFF
--- a/R/gee_helpers.R
+++ b/R/gee_helpers.R
@@ -97,7 +97,7 @@ start_gee_export_task <- function(ee, image, description, region, folder, file_n
     fileNamePrefix = file_name,
     region = region$getInfo()[["coordinates"]],
     scale = scale,
-    maxPixels = reticulate::r_to_py(max_pixels),
+    maxPixels = as.numeric(max_pixels),
     fileFormat = file_format
   )
   task$start()

--- a/R/make_threatened_ecosystems_protection.R
+++ b/R/make_threatened_ecosystems_protection.R
@@ -76,7 +76,7 @@ make_threatened_ecosystems_protection <- function(
   # Create binary mask of intact areas
   if (integrity_type == "eii") {
     med_val <- median_from_rast(integrity_raster) # Median calculated from pre-computed histogram
-    message(glue::glue("Using the global median inactness value ({med_val}) of the {integrity_type} input to define intact areas"))
+    message(glue::glue("The global median intactness value ({med_val}) for the {integrity_type} input is used to define intact areas"))
     mask <- terra::ifel(integrity_aligned >= med_val, 1, 0)
   } else {
     mask <- terra::ifel(integrity_aligned == 0, 1, 0)


### PR DESCRIPTION
Ensures `max_pixels` parameter is correctly converted to a numeric type, to avoid OverflowError on Windows OS.